### PR TITLE
Remove instance of connectionStatusChanged()

### DIFF
--- a/telemetrylib/SQL.cpp
+++ b/telemetrylib/SQL.cpp
@@ -113,7 +113,6 @@ private:
             } else if(connected && !connection) {
                 sock.close();
                 connection = true;
-                emit connectionStatusChanged();
             }
             usleep(50000);
             sock.abort();

--- a/telemetrylib/TCP.cpp
+++ b/telemetrylib/TCP.cpp
@@ -93,7 +93,6 @@ private:
                 sock.close();
                 if (!connection) {
                     connection = true;
-                    emit connectionStatusChanged();
                 }
             } else {
                 sock.abort();


### PR DESCRIPTION
Spawned this change after seeing @MCLiii's comment on #17: https://github.com/badgerloop-software/sc1-driver-io/pull/17/files/9190e8917cf13ac182bfa5796c5b52cf2d801aca#r1238850726

I also included the removal of `emit connectionStatusChanged()` for the same case in `SQL.cpp` as a reminder in case it was relevant for both communication methods.