### PR TITLE
Change millisec from big endian to little endian

### DIFF
--- a/DataProcessor/DataUnpacker.cpp
+++ b/DataProcessor/DataUnpacker.cpp
@@ -26,7 +26,7 @@ E bytesToGeneralData(QByteArray data, int startPos, int endPos, E typeZero)
     int byteNum=endPos-startPos;
     auto var = typeZero;
 
-    for(int i = startPos ; i<=endPos ; i++) {
+    for(int i = endPos ; i>=startPos ; i--) {
         var = var + (((uint8_t) data[i]) << (byteNum * 8));
         byteNum--;
     }

--- a/backendprocesses.cpp
+++ b/backendprocesses.cpp
@@ -88,8 +88,8 @@ void BackendProcesses::threadProcedure()
     bytes.remove(tstampOffsets.sc,1);
     bytes.insert(tstampOffsets.sc, sec_time & 0xFF);
     bytes.remove(tstampOffsets.ms,2);
-    bytes.insert(tstampOffsets.ms, msec_time & 0xFF);
     bytes.insert(tstampOffsets.ms, (msec_time >> 8) & 0xFF);
+    bytes.insert(tstampOffsets.ms, msec_time & 0xFF);
     bytes.remove(tstampOffsets.unix,8);
     uint64_t time=curr_msec;
     int mask= 56;


### PR DESCRIPTION
All our data in the byte array is in little endian except milliseconds.