### PR TITLE
fix spelling error in restart window

### DIFF
--- a/RestartWindow.qml
+++ b/RestartWindow.qml
@@ -812,7 +812,7 @@ Popup {
                             }
 
                             anchors.centerIn: parent
-                            text: "Thermister B value"
+                            text: "Thermistor B value"
                             color: thermistor_b_value_table_invalid_fault ? "red" : "white"
                             font.pointSize: mcu_check_point_size
                             opacity: hidden_opacity


### PR DESCRIPTION
"Thermister" changed to "Thermistor"